### PR TITLE
make flags of a comand visible to its subcommands

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -179,6 +179,21 @@ func (c *Command) Dispatch(args []string) error {
 	// Ensure command is initialized.
 	c.init()
 
+	// Parse flags for this command. Subcommands will be able to
+	// access their values through their parent.
+	if !c.CustomFlags {
+		var err error
+		c.Flag.Usage = func() {
+			c.Usage()
+			err = fmt.Errorf("Failed to parse flags.")
+		}
+		c.Flag.Parse(args)
+		if err != nil {
+			return err
+		}
+		args = c.Flag.Args()
+	}
+
 	// First, try a sub-command
 	if len(args) > 0 {
 		for _, cmd := range c.Subcommands {
@@ -206,18 +221,6 @@ func (c *Command) Dispatch(args []string) error {
 
 	// then, try running this command
 	if c.Runnable() {
-		if !c.CustomFlags {
-			var err = error(nil)
-			c.Flag.Usage = func() {
-				c.Usage()
-				err = fmt.Errorf("Failed to parse flags.")
-			}
-			c.Flag.Parse(args)
-			if err != nil {
-				return err
-			}
-			args = c.Flag.Args()
-		}
 		return c.Run(c, args)
 	}
 


### PR DESCRIPTION
@jbenet let me know how this looks! It works for the use case we have in ipfs, but it does prevent subcommands from having flags with the same name as their parent command. Tradeoffs..
